### PR TITLE
test: Bug-Beweis-Tests und Live-Findings-Tests hinzugefügt

### DIFF
--- a/docs/stabilitaets-analyse.md
+++ b/docs/stabilitaets-analyse.md
@@ -180,7 +180,7 @@ den Test-Teardown.
 
 ## Lücken in der Testabdeckung
 
-Die bestehende Testsuite (65+ Tests) ist für den Happy Path solide. Bemerkenswerte Lücken:
+Die bestehende Testsuite (74 Tests) ist für den Happy Path solide. Bemerkenswerte Lücken:
 
 - **Streaming-Pfad** (`stream: true`) — null Tests
 - **Loop-Erkennung** schlägt auf Fehlermeldungen an, die Erfolgswörter enthalten

--- a/docs/test-ergebnisse.md
+++ b/docs/test-ergebnisse.md
@@ -132,43 +132,7 @@ Keys present: ['role', 'content', 'tool_calls']
 ## Vorgeschlagene Fixes
 
 Alle Priorität-1-Fixes sind voneinander unabhängig und können parallel umgesetzt werden.
-Vollständiger Fix-Plan: [fix-plan.md](fix-plan.md)
-
-### Bug 1 — Loop Detection (`loop_detection.py:60`, 3 Zeilen)
-
-```python
-_ERROR_INDICATORS = ("error", "failed", "could not", "unable to", "exception", "traceback")
-has_success = any(word in lower for word in _WRITE_SUCCESS_WORDS)
-has_error   = any(word in lower for word in _ERROR_INDICATORS)
-if has_success and not has_error:
-    success_count += 1
-```
-
-### Bug 4 — Shell Injection (`tool_call_fixups.py:288`, 2 Zeilen)
-
-```python
-import shlex
-cmd = f"mv {shlex.quote(source)} {shlex.quote(dest)}"
-```
-
-### Bug 7 — `tool_calls`-Schlüssel (`message_normalizer.py:112`, 1 Zeile)
-
-```python
-msg["content"] = "\n".join(xml_parts)
-msg.pop("tool_calls", None)   # ← hinzufügen
-```
-
-### Bug 2 — Text-Synthese-Heuristik (`text_synthesis.py:103`)
-
-```python
-_CODE_MARKERS = ("```", "def ", "class ", "import ", "function ", "const ", "export ")
-looks_like_file_content = (
-    not looks_like_xml_tool_call
-    and len(stripped) > 200
-    and any(marker in stripped for marker in _CODE_MARKERS)
-    and not stripped.lower().startswith(("i ", "the ", "here ", "this ", "let me", "to "))
-)
-```
+Konkrete Code-Snippets und vollständiger Fix-Plan: [fix-plan.md](fix-plan.md)
 
 ---
 

--- a/docs/test-ergebnisse.md
+++ b/docs/test-ergebnisse.md
@@ -1,0 +1,180 @@
+# Testergebnisse & Zusammenfassung
+
+Datum: 2026-03-11
+Modell: `gpt-oss-120b` via LiteLLM (`http://10.3.0.120:4000/v1`)
+
+---
+
+## Test-Setup (macOS)
+
+Die Live-Tests laufen direkt gegen die LiteLLM-Instanz — kein SSH-Tunnel, kein Container nötig.
+
+### Voraussetzungen
+
+```bash
+# API-Key dauerhaft in der Shell speichern
+echo 'export LITELLM_MASTER_KEY="dein-key-hier"' >> ~/.zshrc
+source ~/.zshrc
+
+# Abhängigkeiten installieren
+pip install -r requirements.txt -r requirements-test.txt
+```
+
+### `.env` für lokalen Proxy-Start (optional)
+
+```
+UPSTREAM_URL=http://10.3.0.120:4000/v1
+UPSTREAM_MODEL=openai/gpt-oss-120b
+UPSTREAM_API_KEY=<LITELLM_MASTER_KEY>
+LOG_LEVEL=DEBUG
+```
+
+### Tests ausführen
+
+```bash
+# Unit-Tests (kein Modell nötig, ~0.1s)
+python3 -m pytest tests/ --ignore=tests/live -v
+
+# Bug-Beweis-Tests (kein Modell nötig — schlagen aktuell fehl, absichtlich)
+python3 -m pytest tests/test_bug_proof.py -v
+
+# Live-Tests gegen echtes Modell (~9 Minuten)
+python3 -m pytest -m live -v
+
+# Nur Findings-Tests live
+python3 -m pytest -m live -v tests/live/test_findings.py
+```
+
+### Hinweis: `conftest.py`-Änderung
+
+`tests/live/conftest.py` war ursprünglich auf `localhost:8005` hardcodiert (SSH-Tunnel nötig).
+Wurde auf Env-Variablen umgestellt — funktioniert jetzt ohne Tunnel direkt gegen LiteLLM:
+
+| Env-Variable | Default | Beschreibung |
+|---|---|---|
+| `LIVE_UPSTREAM_URL` | `http://10.3.0.120:4000/v1` | LiteLLM-Endpoint |
+| `LIVE_MODEL` | `openai/gpt-oss-120b` | Modell-Name |
+| `LIVE_API_KEY` | `$LITELLM_MASTER_KEY` | API-Key |
+
+---
+
+## Gefundene Bugs (Statische Code-Analyse)
+
+| # | Schwere | Datei | Problem |
+|---|---|---|---|
+| 1 | **Mittel** | `loop_detection.py:60` | Fehlermeldungen mit Wörtern wie `"created"` lösen den Erfolgs-Loop-Detektor aus — Modell bekommt falschen STOP-Hinweis mitten in einer Aufgabe |
+| 2 | **Mittel** | `text_synthesis.py:103` | Prosa-Antworten >200 Zeichen mit `\n\n` können stillschweigend in eine offene Datei geschrieben werden — Datenverlust-Risiko |
+| 3 | **Mittel** | `xml_parser.py:55` | Lazy-Regex kürzt XML, wenn `<content>` denselben Tag-Namen enthält wie das äußere Tool |
+| 4 | **Mittel** | `tool_call_fixups.py:288` | Dateipfade mit Apostrophen (z.B. `user's notes.txt`) erzeugen ungültige Shell-Befehle — `mv 'user's notes.txt'` ist kein valides Syntax |
+| 5 | **Mittel** | `main.py:72` | Kein Startschutz — Anfragen vor Abschluss des Lifespans crashen mit undurchsichtigem 500-Fehler |
+| 6 | **Mittel** | `main.py:167` | Keine Request-Body-Validierung — fehlerhafte Eingaben crashen mit 500 statt 422 |
+| 7 | **Niedrig** | `message_normalizer.py:112` | `tool_calls`-Schlüssel wird nach XML-Konvertierung nicht entfernt — Upstream erhält beide Formate |
+
+---
+
+## Testergebnisse gegen echtes Modell
+
+### Standard-Live-Tests — 16/16 bestanden
+
+```
+test_write_to_file          ✅
+test_read_file              ✅
+test_apply_diff             ✅
+test_list_files             ✅
+test_delete_file            ✅
+test_execute_command        ✅
+test_attempt_completion     ✅  (transientes Timeout beim ersten Lauf, beim Retry ok — Upstream war ausgelastet)
+test_ask_followup_question  ✅
+test_search_files           ✅
+test_write (OpenCode)       ✅
+test_read (OpenCode)        ✅
+test_list (OpenCode)        ✅
+test_bash (OpenCode)        ✅
+test_edit (OpenCode)        ✅
+test_glob (OpenCode)        ✅
+test_grep (OpenCode)        ✅
+```
+
+**Fazit:** Der Happy Path ist stabil. Die gefundenen Bugs liegen in Edge-Case/Fallback-Schichten und werden nur durch spezifische Modell-Ausgaben ausgelöst.
+
+---
+
+### Bug-Beweis-Unit-Tests — 5 schlagen fehl (Bugs bestätigt)
+
+Diese Tests brauchen kein Modell — sie testen die Proxy-Logik direkt.
+Datei: `tests/test_bug_proof.py`
+
+```
+test_error_message_with_success_word_does_not_trigger_loop  ❌ BUG BESTÄTIGT
+test_error_only_never_triggers_loop                         ❌ BUG BESTÄTIGT
+test_apostrophe_in_source_path_produces_valid_shell_command ❌ BUG BESTÄTIGT
+test_apostrophe_in_dest_path_produces_valid_shell_command   ❌ BUG BESTÄTIGT
+test_normalized_assistant_message_has_no_tool_calls_key     ❌ BUG BESTÄTIGT
+```
+
+Fehlermeldungen (Auszug):
+
+```
+BUG: Loop detection fired on an error message.
+Hint injected: 'STOP: The file operation has already succeeded 2 times...'
+Cause: 'created' in error message counted as a success.
+
+BUG: Shell command has broken quoting (apostrophe injection).
+Command: "mv 'user's notes.txt' 'dest.txt'"
+shlex error: No closing quotation
+
+BUG: tool_calls key still present after normalization.
+Keys present: ['role', 'content', 'tool_calls']
+```
+
+---
+
+## Vorgeschlagene Fixes
+
+Alle Priorität-1-Fixes sind voneinander unabhängig und können parallel umgesetzt werden.
+Vollständiger Fix-Plan: [fix-plan.md](fix-plan.md)
+
+### Bug 1 — Loop Detection (`loop_detection.py:60`, 3 Zeilen)
+
+```python
+_ERROR_INDICATORS = ("error", "failed", "could not", "unable to", "exception", "traceback")
+has_success = any(word in lower for word in _WRITE_SUCCESS_WORDS)
+has_error   = any(word in lower for word in _ERROR_INDICATORS)
+if has_success and not has_error:
+    success_count += 1
+```
+
+### Bug 4 — Shell Injection (`tool_call_fixups.py:288`, 2 Zeilen)
+
+```python
+import shlex
+cmd = f"mv {shlex.quote(source)} {shlex.quote(dest)}"
+```
+
+### Bug 7 — `tool_calls`-Schlüssel (`message_normalizer.py:112`, 1 Zeile)
+
+```python
+msg["content"] = "\n".join(xml_parts)
+msg.pop("tool_calls", None)   # ← hinzufügen
+```
+
+### Bug 2 — Text-Synthese-Heuristik (`text_synthesis.py:103`)
+
+```python
+_CODE_MARKERS = ("```", "def ", "class ", "import ", "function ", "const ", "export ")
+looks_like_file_content = (
+    not looks_like_xml_tool_call
+    and len(stripped) > 200
+    and any(marker in stripped for marker in _CODE_MARKERS)
+    and not stripped.lower().startswith(("i ", "the ", "here ", "this ", "let me", "to "))
+)
+```
+
+---
+
+## Nächste Schritte
+
+1. **Sofort:** Bug 1, 4 und 7 fixen — jeweils 1-3 Zeilen, unabhängig voneinander
+2. **Validierung:** `python3 -m pytest tests/test_bug_proof.py -v` muss danach grün sein
+3. **Regression:** `python3 -m pytest tests/ --ignore=tests/live -v` — alle 74 bestehenden Tests müssen weiterhin bestehen
+4. **Strategisch:** Constrained-Decoding-Spike in vLLM — siehe [architektur-und-roadmap.md](architektur-und-roadmap.md)

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -9,6 +9,7 @@ Run:
 """
 import asyncio
 import json
+import os
 import pytest
 from unittest.mock import patch
 
@@ -23,8 +24,9 @@ SYSTEM_MSG = {"role": "system", "content": "You are a coding assistant. Use tool
 
 
 def post(client, tools, prompt, system=SYSTEM_MSG):
+    model = os.environ.get("LIVE_MODEL", "openai/gpt-oss-120b")
     resp = client.post("/v1/chat/completions", json={
-        "model": "oracle-llm",
+        "model": model,
         "messages": [system, user_msg(prompt)],
         "tools": tools,
     })
@@ -155,13 +157,23 @@ OPEN_CODE_TOOLS = [
 @pytest.fixture(scope="module")
 def live(client):
     """
-    Replace the module-level upstream_client with a real VLLMClient
-    pointing at oci-proxy on localhost:8005. No mocking.
+    Replace the module-level upstream_client with a real VLLMClient.
+
+    Reads connection settings from environment variables so the same tests
+    work on any setup without editing this file:
+
+        LIVE_UPSTREAM_URL   — default: http://10.3.0.120:4000/v1
+        LIVE_MODEL          — default: openai/gpt-oss-120b
+        LIVE_API_KEY        — default: $LITELLM_MASTER_KEY (then "dummy-key")
     """
+    base_url = os.environ.get("LIVE_UPSTREAM_URL", "http://10.3.0.120:4000/v1")
+    model = os.environ.get("LIVE_MODEL", "openai/gpt-oss-120b")
+    api_key = os.environ.get("LIVE_API_KEY") or os.environ.get("LITELLM_MASTER_KEY", "dummy-key")
+
     real_uc = VLLMClient(
-        base_url="http://localhost:8005/v1",
-        model="oracle-llm",
-        api_key="dummy-key",
+        base_url=base_url,
+        model=model,
+        api_key=api_key,
         timeout=120,
         max_retries=1,
     )

--- a/tests/live/conftest.py
+++ b/tests/live/conftest.py
@@ -1,10 +1,13 @@
 """
 Shared fixtures and tool definitions for live integration tests.
 
-Requires oci-proxy accessible on localhost:8005 (e.g. via SSH tunnel):
-    ssh -L 8005:localhost:8005 remote-host
+Verbindungseinstellungen via Env-Variablen (kein SSH-Tunnel nötig):
 
-Run:
+    export LITELLM_MASTER_KEY="dein-key"
+    export LIVE_UPSTREAM_URL="http://10.3.0.120:4000/v1"   # optional, das ist der Default
+    export LIVE_MODEL="openai/gpt-oss-120b"                 # optional, das ist der Default
+
+Ausführen:
     cd toolproxy && python3 -m pytest -m live -v
 """
 import asyncio

--- a/tests/live/test_findings.py
+++ b/tests/live/test_findings.py
@@ -1,0 +1,149 @@
+"""
+Live regression tests for findings from the stability analysis.
+See docs/stabilitaets-analyse.md for full issue descriptions.
+
+Run:
+    python3 -m pytest -m live -v tests/live/test_findings.py
+"""
+import shlex
+import pytest
+from tests.live.conftest import (
+    ROO_CODE_TOOLS,
+    TOOL_WRITE_TO_FILE, TOOL_ATTEMPT_COMPLETION, TOOL_EXECUTE_COMMAND,
+    post, parse_tool_call,
+)
+
+pytestmark = pytest.mark.live
+
+
+def post_multi_turn(client, tools, messages):
+    """Post a full pre-built message list rather than a single user prompt."""
+    import os
+    model = os.environ.get("LIVE_MODEL", "openai/gpt-oss-120b")
+    resp = client.post("/v1/chat/completions", json={
+        "model": model,
+        "messages": messages,
+        "tools": tools,
+    })
+    assert resp.status_code == 200, resp.text
+    return resp.json()
+
+
+class TestLoopDetectionFalsePositive:
+    """
+    Finding: Loop detection fires on error messages containing success words.
+
+    Scenario: two consecutive tool results where the first contains "created"
+    inside an error message. The proxy should NOT inject a stop hint — the
+    model must be allowed to continue writing files.
+
+    If the bug is present: proxy injects STOP hint → model calls attempt_completion
+    If the bug is fixed:   proxy stays silent   → model calls write_to_file
+    """
+
+    def test_error_message_with_success_word_does_not_trigger_loop(self, live):
+        messages = [
+            {"role": "system", "content": "You are a coding assistant. Use tools to complete tasks."},
+            {"role": "user", "content": "Write hello.py and then goodbye.py."},
+            # Simulated assistant turn: model called write_to_file for hello.py
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "call_001",
+                "type": "function",
+                "function": {"name": "write_to_file", "arguments": '{"path": "hello.py", "content": "print(\'hello\')"}'},
+            }]},
+            # Tool result 1: error message containing the word "created" → should NOT count as success
+            {"role": "tool", "tool_call_id": "call_001", "content": "Error: file could not be created — permission denied"},
+            # Simulated retry: model calls write_to_file again
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "call_002",
+                "type": "function",
+                "function": {"name": "write_to_file", "arguments": '{"path": "hello.py", "content": "print(\'hello\')"}'},
+            }]},
+            # Tool result 2: genuine success
+            {"role": "tool", "tool_call_id": "call_002", "content": "File written successfully"},
+            # Now ask for the next file — proxy should NOT have injected STOP hint
+            {"role": "user", "content": "Good. Now write goodbye.py with print('goodbye')."},
+        ]
+
+        resp = post_multi_turn(live, ROO_CODE_TOOLS, messages)
+        name, args = parse_tool_call(resp)
+
+        # If loop detection false-positived, proxy injected a STOP hint and the
+        # model likely called attempt_completion instead of writing the file.
+        assert name == "write_to_file", (
+            f"Expected write_to_file but got {name!r} — "
+            "loop detection likely fired on the error message containing 'created'"
+        )
+        assert args.get("path") == "goodbye.py"
+
+
+class TestShellInjection:
+    """
+    Finding: move_file → execute_command conversion uses single-quoted paths.
+    A path containing an apostrophe breaks the shell command.
+
+    The proxy converts move_file(source="user's notes.txt", destination="notes.txt")
+    to execute_command(command="mv 'user's notes.txt' 'notes.txt'") — broken shell syntax.
+
+    After fix (shlex.quote): mv 'user'"'"'s notes.txt' notes.txt — valid shell.
+    """
+
+    def test_apostrophe_in_path_produces_valid_shell_command(self, live):
+        # Only offer execute_command so the model is forced to use move_file or
+        # execute_command directly. The proxy converts move_file → execute_command.
+        tools = [TOOL_EXECUTE_COMMAND, TOOL_ATTEMPT_COMPLETION]
+        resp = post(live, tools,
+                    "Rename the file \"user's notes.txt\" to \"users_notes.txt\". "
+                    "Use move_file or execute_command.")
+        name, args = parse_tool_call(resp)
+
+        assert name == "execute_command", f"Expected execute_command, got {name!r}"
+        cmd = args.get("command", "")
+        assert cmd, "execute_command has no 'command' argument"
+
+        # The command must be parseable by the shell — shlex.split() raises
+        # ValueError if the quoting is broken (e.g. unmatched single quote).
+        try:
+            parts = shlex.split(cmd)
+        except ValueError as e:
+            pytest.fail(
+                f"Shell command has broken quoting (apostrophe injection bug): {cmd!r}\n"
+                f"shlex error: {e}"
+            )
+
+        # The parsed command must contain the filename with the apostrophe intact.
+        full_cmd = " ".join(parts)
+        assert "user" in full_cmd and "notes" in full_cmd, (
+            f"Filename not found in parsed command: {parts}"
+        )
+
+
+class TestMultiTurnNormalization:
+    """
+    Finding: tool_calls key not removed from assistant messages after normalization.
+    Upstream receives both content (XML) and tool_calls — potential schema violation.
+
+    This test verifies that multi-turn conversations with prior tool_calls in history
+    work correctly end-to-end (the upstream doesn't reject the request).
+    """
+
+    def test_multi_turn_with_prior_tool_call_in_history(self, live):
+        messages = [
+            {"role": "system", "content": "You are a coding assistant. Use tools to complete tasks."},
+            {"role": "user", "content": "Read README.md"},
+            # Prior assistant turn with tool_calls in history — proxy must normalize this
+            {"role": "assistant", "content": None, "tool_calls": [{
+                "id": "call_001",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": '{"path": "README.md"}'},
+            }]},
+            {"role": "tool", "tool_call_id": "call_001", "content": "# My Project\nThis is the README."},
+            {"role": "user", "content": "Now write a file called summary.md with a one-line summary of what you read."},
+        ]
+
+        resp = post_multi_turn(live, ROO_CODE_TOOLS, messages)
+        name, args = parse_tool_call(resp)
+
+        assert name == "write_to_file", f"Expected write_to_file, got {name!r}"
+        assert args.get("path") == "summary.md"
+        assert "content" in args

--- a/tests/test_bug_proof.py
+++ b/tests/test_bug_proof.py
@@ -1,0 +1,201 @@
+"""
+Failing tests that PROVE the bugs found in static analysis exist.
+
+Each test is written to FAIL against the current code and PASS after the fix
+is applied. Run before fixing to see red, run after fixing to see green.
+
+See docs/stabilitaets-analyse.md for full issue descriptions.
+See docs/fix-plan.md for the corresponding fixes.
+"""
+import shlex
+import json
+import pytest
+
+from app.services.loop_detection import detect_success_loop
+from app.services.message_normalizer import normalize_messages
+from app.services.tool_call_fixups import convert_move_file_to_execute_command
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BUG 1: Loop detection false positive
+# File: app/services/loop_detection.py:60
+#
+# Word-matching fires even when the tool result is an ERROR.
+# "Error: file could not be created" contains "created" → increments counter.
+#
+# Fix: also check that the content does NOT contain error-indicating words.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestLoopDetectionFalsePositive:
+
+    def test_error_message_with_success_word_does_not_trigger_loop(self):
+        """
+        Two tool results: first is an ERROR containing 'created', second is a
+        real success. The loop hint must NOT fire — only 1 real success exists.
+
+        FAILS today:  'created' in error message increments counter to 1,
+                      'successfully' increments to 2 → stop hint injected (wrong)
+        PASSES after fix: error indicator suppresses the first increment → count=1 → no hint
+        """
+        messages = [
+            {"role": "user", "content": "Write hello.py"},
+            {"role": "user", "content": "[Tool Result]\nError: file could not be created — permission denied"},
+            {"role": "user", "content": "[Tool Result]\nFile written successfully"},
+        ]
+        result = detect_success_loop(messages)
+        assert result is None, (
+            f"BUG: Loop detection fired on an error message.\n"
+            f"Hint injected: {result!r}\n"
+            f"Cause: 'created' in error message counted as a success."
+        )
+
+    def test_two_real_successes_still_trigger_loop(self):
+        """
+        Sanity check: two genuine successes must still trigger the loop hint.
+        This must keep passing before AND after the fix.
+        """
+        messages = [
+            {"role": "user", "content": "Write some files"},
+            {"role": "user", "content": "[Tool Result]\nFile written successfully"},
+            {"role": "user", "content": "[Tool Result]\nFile created successfully"},
+        ]
+        result = detect_success_loop(messages)
+        assert result is not None, "Two real successes must still trigger the loop hint"
+
+    def test_error_only_never_triggers_loop(self):
+        """
+        Two error messages — even if both contain success words — must not trigger.
+
+        FAILS today: both contain "created" → count=2 → hint fires (wrong)
+        PASSES after fix: error indicator suppresses both → count=0 → no hint
+        """
+        messages = [
+            {"role": "user", "content": "Write some files"},
+            {"role": "user", "content": "[Tool Result]\nError: directory could not be created"},
+            {"role": "user", "content": "[Tool Result]\nError: file was not written — disk full"},
+        ]
+        result = detect_success_loop(messages)
+        assert result is None, (
+            f"BUG: Loop detection fired on two error messages.\n"
+            f"Hint injected: {result!r}\n"
+            f"Cause: success words in error messages counted as successes."
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BUG 2: Shell injection via apostrophe in file path
+# File: app/services/tool_call_fixups.py:288
+#
+# cmd = f"mv '{source}' '{dest}'"
+# A path like "user's notes.txt" produces: mv 'user's notes.txt' 'dest'
+# → broken shell syntax (unmatched single quote)
+#
+# Fix: use shlex.quote(source) and shlex.quote(dest)
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestShellInjectionApostrophe:
+
+    def _get_mv_command(self, source: str, dest: str) -> str:
+        """Helper: run the move_file fixup and return the mv command string."""
+        tool_calls = [{
+            "id": "call_001",
+            "type": "function",
+            "function": {
+                "name": "move_file",
+                "arguments": json.dumps({"source": source, "destination": dest}),
+            },
+        }]
+        result = convert_move_file_to_execute_command(
+            tool_calls, ["execute_command"], request_id="test"
+        )
+        assert result, "Expected a tool call result"
+        assert result[0]["function"]["name"] == "execute_command"
+        return json.loads(result[0]["function"]["arguments"])["command"]
+
+    def test_apostrophe_in_source_path_produces_valid_shell_command(self):
+        """
+        source = "user's notes.txt" → mv command must be valid shell syntax.
+
+        FAILS today:  mv 'user's notes.txt' 'dest.txt'  ← broken quoting
+        PASSES after fix: shlex.quote produces valid escaping
+        """
+        cmd = self._get_mv_command("user's notes.txt", "dest.txt")
+        try:
+            parts = shlex.split(cmd)
+        except ValueError as e:
+            pytest.fail(
+                f"BUG: Shell command has broken quoting (apostrophe injection).\n"
+                f"Command: {cmd!r}\n"
+                f"shlex error: {e}\n"
+                f"Fix: use shlex.quote() instead of f\"mv '{{source}}' '{{dest}}'\""
+            )
+        # After correct parsing, the original filename must be intact
+        assert "user's notes.txt" in parts, (
+            f"Filename not preserved after quoting. Parsed parts: {parts}"
+        )
+
+    def test_apostrophe_in_dest_path_produces_valid_shell_command(self):
+        """Apostrophe in destination path must also be handled."""
+        cmd = self._get_mv_command("source.txt", "laura's folder/dest.txt")
+        try:
+            parts = shlex.split(cmd)
+        except ValueError as e:
+            pytest.fail(
+                f"BUG: Apostrophe in destination path breaks shell command.\n"
+                f"Command: {cmd!r}\n"
+                f"shlex error: {e}"
+            )
+        assert "laura's folder/dest.txt" in parts
+
+    def test_normal_path_without_apostrophe_still_works(self):
+        """Sanity check: normal paths must keep working before and after the fix."""
+        cmd = self._get_mv_command("old_folder", "new_folder")
+        parts = shlex.split(cmd)
+        assert parts == ["mv", "old_folder", "new_folder"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# BUG 3: tool_calls key not removed after normalization
+# File: app/services/message_normalizer.py:112
+#
+# After converting tool_calls to XML in content, the tool_calls key is not
+# popped from the message dict. The upstream receives both keys.
+#
+# Fix: add msg.pop("tool_calls", None) after writing XML to content.
+# ─────────────────────────────────────────────────────────────────────────────
+
+class TestToolCallsKeyNotRemovedAfterNormalization:
+
+    def test_normalized_assistant_message_has_no_tool_calls_key(self):
+        """
+        An assistant message with tool_calls must NOT have the tool_calls key
+        after normalization — it must be replaced by XML in content.
+
+        FAILS today:  tool_calls key is still present after normalization
+        PASSES after fix: msg.pop("tool_calls", None) removes it
+        """
+        messages = [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [{
+                    "id": "call_001",
+                    "type": "function",
+                    "function": {
+                        "name": "write_to_file",
+                        "arguments": json.dumps({"path": "foo.py", "content": "print('hi')"}),
+                    },
+                }],
+            }
+        ]
+        normalized = normalize_messages(messages, request_id="test")
+        msg = normalized[0]
+
+        assert "tool_calls" not in msg, (
+            f"BUG: tool_calls key still present after normalization.\n"
+            f"Upstream receives both content (XML) and tool_calls (OpenAI format).\n"
+            f"Keys present: {list(msg.keys())}\n"
+            f"Fix: add msg.pop('tool_calls', None) in message_normalizer.py:112"
+        )
+        assert msg["content"], "content must have XML after normalization"
+        assert "write_to_file" in msg["content"], "XML must contain the tool name"


### PR DESCRIPTION
- tests/test_bug_proof.py: 5 Unit-Tests die Bugs beweisen (schlagen aktuell
  absichtlich fehl — werden grün sobald die Fixes eingespielt sind)
- tests/live/test_findings.py: 3 Live-Tests gegen echtes Modell für spezifische
  Findings aus der Stabilitätsanalyse
- tests/live/conftest.py: Verbindungseinstellungen jetzt via Env-Variablen
  (LIVE_UPSTREAM_URL, LIVE_MODEL, LIVE_API_KEY) statt hardcodiertem localhost:8005
  — kein SSH-Tunnel mehr nötig
- docs/test-ergebnisse.md: vollständige Testergebnis-Zusammenfassung inkl. Bug-Nachweise